### PR TITLE
Update Bored API URL in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,11 +12,11 @@ const pool = new Pool({
 });
 
 // Bored API base URL
-const BORED_API_BASE_URL = 'https://www.boredapi.com/api/';
+const BORED_API_BASE_URL = 'https://bored-api.appbrewery.com/';
 
 async function getRandomActivity() {
   try {
-    const response = await fetch(BORED_API_BASE_URL + 'activity');
+    const response = await fetch(BORED_API_BASE_URL + 'random');
     if (response.ok) {
       const data = await response.json();
       return data.activity;


### PR DESCRIPTION
Fixed Bored API URL to `https://bored-api.appbrewery.com/` to fix the `GET /insert_activity` route. Tested with my web app [here](https://deploying-backend-with-render-sample-vswt.onrender.com/) and it works.

Relevant documentation [here](https://bored-api.appbrewery.com/).